### PR TITLE
mr_rqt: add moc_run patch

### DIFF
--- a/mr_rqt/include/mr_rqt/MrRqt.h
+++ b/mr_rqt/include/mr_rqt/MrRqt.h
@@ -32,10 +32,12 @@
 #include <iostream>
 #include <set>
 
-#include <boost/foreach.hpp>
-#include <boost/date_time.hpp>
-#include <boost/thread.hpp>
-#include <boost/algorithm/string.hpp>
+#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+# include <boost/foreach.hpp>
+# include <boost/date_time.hpp>
+# include <boost/thread.hpp>
+# include <boost/algorithm/string.hpp>
+#endif
 
 #include <ros/ros.h>
 #include <std_msgs/String.h>


### PR DESCRIPTION
Fixes build issues with mr_rqt package and newer versions of boost (1.48 -> 1.54).
